### PR TITLE
PLF-6375 : ignore malformed input

### DIFF
--- a/component/common/src/main/java/org/exoplatform/commons/utils/CharsetCharEncoder.java
+++ b/component/common/src/main/java/org/exoplatform/commons/utils/CharsetCharEncoder.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 
 
 /**
@@ -72,6 +73,8 @@ public class CharsetCharEncoder implements CharEncoder {
          */
         try {
             CharsetEncoder encoder = charset.newEncoder();
+            // ignore malformed input
+            encoder.onMalformedInput(CodingErrorAction.IGNORE);
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             OutputStreamWriter writer = new OutputStreamWriter(baos, encoder);
             writer.write(c);

--- a/component/common/src/main/java/org/exoplatform/commons/utils/CharsetTextEncoder.java
+++ b/component/common/src/main/java/org/exoplatform/commons/utils/CharsetTextEncoder.java
@@ -60,7 +60,8 @@ public final class CharsetTextEncoder implements TextEncoder {
             byte[] bytes = charEncoder.encode(c);
             switch (bytes.length) {
                 case 0:
-                    throw new AssertionError();
+                    // ignore empty result (malformed input)
+                    break;
                 case 1:
                     out.write(bytes[0]);
                     break;

--- a/component/common/src/test/java/org/exoplatform/commons/utils/TestTextEncoder.java
+++ b/component/common/src/test/java/org/exoplatform/commons/utils/TestTextEncoder.java
@@ -35,6 +35,11 @@ public class TestTextEncoder extends AbstractGateInTest {
 
     public void testA() throws IOException {
         assertOK("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+        // check if ignore malformed input
+        String malformedInput = new String(new byte[]{(byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x80});
+        assertOK("hello you", "hello " + malformedInput + "you");
+
         /*
          * assertOK("<>&\"\\=+");
          *
@@ -49,24 +54,28 @@ public class TestTextEncoder extends AbstractGateInTest {
          */
     }
 
-    private void assertOK(String s) throws IOException {
+    private void assertOK(String expectedAndActual) throws IOException {
+        assertOK(expectedAndActual, expectedAndActual);
+    }
+
+    private void assertOK(String expected, String actual) throws IOException {
         TextEncoder encoder = CharsetTextEncoder.getUTF8();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        encoder.encode(s, 0, s.length(), baos);
+        encoder.encode(actual, 0, actual.length(), baos);
         baos.flush();
         byte[] b1 = baos.toByteArray();
 
         //
         baos.reset();
         OutputStreamWriter osw = new OutputStreamWriter(baos);
-        osw.write(s);
+        osw.write(expected);
         osw.close();
         byte[] b2 = baos.toByteArray();
 
         //
-        List<Byte> expected = toList(b2);
-        List<Byte> actual = toList(b1);
-        assertEquals(expected, actual);
+        List<Byte> expectedBytes = toList(b2);
+        List<Byte> actualBytes = toList(b1);
+        assertEquals(expectedBytes, actualBytes);
     }
 
     private List<Byte> toList(byte[] bytes) {


### PR DESCRIPTION
This fix does not allow to display characters considered as malformed (which is the case for the emojis for example) correctly, it only allows to ignore them. So it avoids the application to crash.