### PR TITLE
EXOGTN-2219: Organization Service is null when IDMUserListAccess is used in a listener

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/IDMUserListAccess.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/IDMUserListAccess.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserStatus;
@@ -161,7 +162,6 @@ public class IDMUserListAccess implements ListAccess<User>, Serializable {
     }
 
     PicketLinkIDMOrganizationServiceImpl getOrganizationService() {
-        return (PicketLinkIDMOrganizationServiceImpl) ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(
-                OrganizationService.class);
+        return (PicketLinkIDMOrganizationServiceImpl) PortalContainer.getInstance().getComponentInstanceOfType(OrganizationService.class);
     }
 }


### PR DESCRIPTION
Organization service is null when IDMUserListAccess is used by a listener
The fix will make sure to get the service from the portal container statically.