### PR TITLE
EXOGTN-2235 Load navigations on startup

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/navigation/NavigationServiceWrapper.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/navigation/NavigationServiceWrapper.java
@@ -171,6 +171,7 @@ public class NavigationServiceWrapper implements NavigationService, Startable {
                 session.logout();
             }
         }
+        this.service.start();
     }
 
     public void stop() {

--- a/component/portal/src/main/java/org/exoplatform/portal/pom/config/POMSessionManager.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/pom/config/POMSessionManager.java
@@ -228,4 +228,7 @@ public class POMSessionManager implements Startable {
         return executor.execute(session, task);
     }
 
+    public ChromatticManager getChromatticManager() {
+      return manager;
+    }
 }


### PR DESCRIPTION
While the server starts up, we can improve first experience of user by minimizing the first page loading time.
This PR adds a start method in NavigationServiceImpl that will populate the cache with Navigations data.