### PR TITLE
EXOGTN-2260 : Make gatein-portal build in Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,9 @@
   <name>GateIn - Portal</name>
 
   <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    
     <org.exoplatform.kernel.version>5.0.x-SNAPSHOT</org.exoplatform.kernel.version>
     <org.exoplatform.core.version>5.0.x-SNAPSHOT</org.exoplatform.core.version>
     <org.exoplatform.ws.version>5.0.x-SNAPSHOT</org.exoplatform.ws.version>
@@ -106,7 +109,7 @@
     <version.plugin.clean>2.4.1</version.plugin.clean>
     <version.yuicompressor-maven-plugin>0.7.1</version.yuicompressor-maven-plugin>
     <version.plugin.japex>1.2.3</version.plugin.japex>
-
+    <version.plugin.jibx>1.3.1</version.plugin.jibx>
 
   </properties>
 
@@ -1296,7 +1299,7 @@ memory option properties. This should be removed when we can just set the compil
         <plugin>
           <groupId>org.jibx</groupId>
           <artifactId>maven-jibx-plugin</artifactId>
-          <version>1.2.2</version>
+          <version>${version.plugin.jibx}</version>
           <dependencies>
             <!--Workaround https://issues.apache.org/jira/browse/BCEL-173-->
             <dependency>
@@ -1369,7 +1372,7 @@ memory option properties. This should be removed when we can just set the compil
                     <artifactId>
                       maven-jibx-plugin
                     </artifactId>
-                    <versionRange>[1.2.2,)</versionRange>
+                    <versionRange>[${version.plugin.jibx},)</versionRange>
                     <goals>
                       <goal>bind</goal>
                     </goals>


### PR DESCRIPTION
* sets target and source to 1.8
* upgrades maven jibx plugin to 1.3.1 to support Java 8