### PR TITLE
EXOGTN-2261 Avoid loading the CSS links twice

### DIFF
--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/CompositeSkin.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/CompositeSkin.java
@@ -52,6 +52,10 @@ class CompositeSkin implements Skin {
     private final String urlPrefix;
 
     CompositeSkin(SkinService service, Collection<SkinConfig> skins) {
+        this(service, skins, null);
+    }
+
+    CompositeSkin(SkinService service, Collection<SkinConfig> skins, String compositeId) {
         TreeMap<String, SkinConfig> urlSkins = new TreeMap<String, SkinConfig>();
         for (SkinConfig skin : skins) {
             urlSkins.put(skin.getCSSPath(), skin);
@@ -82,7 +86,11 @@ class CompositeSkin implements Skin {
 
         //
         this.service = service;
-        this.id = id.toString();
+        if (compositeId != null) {
+            this.id = compositeId;
+        } else {
+            this.id = id.toString();
+        }
         this.urlPrefix = builder.toString();
     }
 

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/SkinService.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/SkinService.java
@@ -370,7 +370,11 @@ public class SkinService extends AbstractResourceService implements Startable {
      * @return the merged skin
      */
     public Skin merge(Collection<SkinConfig> skins) {
-        return new CompositeSkin(this, skins);
+        return merge(skins, null);
+    }
+
+    public Skin merge(Collection<SkinConfig> skins, String id) {
+        return new CompositeSkin(this, skins, id);
     }
 
     /**

--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/Skin.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/Skin.js
@@ -17,23 +17,34 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-(function() {
-	eXo.core.Skin = {
-			/**
-			 * Adds a css file, idnetified by url, to the page
-			 * componentId identifies the component to which the style applies
-			 */
-			addSkin : function(componentId, url) {
-				var skin = document.getElementById(componentId) ;
-				if(skin != null) return ;
-				var link = document.createElement('link') ;
-				link.setAttribute('id', componentId) ;
-				link.setAttribute('rel', 'stylesheet') ;
-				link.setAttribute('type', 'text/css') ;
-				link.setAttribute('href', url) ;
-				var head = document.getElementsByTagName("head")[0] ;
-				head.appendChild(link) ;
-			}
-	};
-	return eXo.core.Skin;	
+(function () {
+  eXo.core.Skin = {
+    /**
+     * Adds a css file, idnetified by url, to the page
+     * componentId identifies the component to which the style applies
+     */
+    addSkin: function (componentId, url, replaceIfExist) {
+      var link = document.getElementById(componentId);
+      if (link != null) {
+        if (replaceIfExist) {
+          link.setAttribute('href', url);
+        }
+        return;
+      }
+
+      link = document.createElement('link');
+      link.setAttribute('id', componentId);
+      link.setAttribute('rel', 'stylesheet');
+      link.setAttribute('type', 'text/css');
+      link.setAttribute('href', url);
+      var head = document.getElementsByTagName("head")[0];
+      var customModule = document.getElementById("customModule");
+      if (customModule) {
+        head.insertBefore(link, customModule);
+      } else {
+        head.appendChild(link);
+      }
+    }
+  };
+  return eXo.core.Skin;
 })();


### PR DESCRIPTION
For some full ajax update actions, the CSS of portlets inside the portal layout are re-loaded separately while they were actually loaded in a combination link.

So to fix this, we detect portlets updated in portal layout and reload the CSS combination link of portal portlet skins