### PR TITLE
[EXOGTN-2275] Exception when trying to retrieve nested groups after u…

### DIFF
--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -14,6 +14,7 @@ import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.ldap.LdapContext;
 import java.util.HashSet;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.logging.Level;
@@ -81,7 +82,11 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
             String name = nameAttribute.get().toString();
             LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
             String filter = getTypeConfiguration(ctx, match).getEntrySearchFilter();
-            if ((entry != null && Tools.dnEquals(entry.getDn(), dn)) || filter != null) {
+            String[] entryCtxs = getTypeConfiguration(ctx, match).getCtxDNs();
+            String scope = getTypeConfiguration(ctx, match).getEntrySearchScope();
+            Object[] filterArgs = {name};
+            List<SerializableSearchResult> searchResult = searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[]{getTypeConfiguration(ctx, match).getIdAttributeName()}, scope, null);
+            if ((entry != null && Tools.dnEquals(entry.getDn(), dn)) || (filter != null && searchResult.size() == 0)) {
               type = match;
               break;
             }

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -80,7 +80,8 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
           LDAPIdentityObjectTypeConfiguration typeConfiguration = getTypeConfiguration(ctx, match);
           Name jndiName = new CompositeName().add(dn);
           Attributes attrs = ldapContext.getAttributes(jndiName);
-          Attribute nameAttribute = attrs.get(typeConfiguration.getIdAttributeName());
+          String idAttributeName = typeConfiguration.getIdAttributeName();
+          Attribute nameAttribute = attrs.get(idAttributeName);
           String filter = getTypeConfiguration(ctx, match).getEntrySearchFilter();
           String[] entryCtxs = getTypeConfiguration(ctx, match).getCtxDNs();
           String scope = getTypeConfiguration(ctx, match).getEntrySearchScope();
@@ -88,7 +89,7 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
             String name = nameAttribute.get().toString();
             Object[] filterArgs = { name };
             if (filter != null) {
-              searchResult = this.searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[] { getTypeConfiguration(ctx, match).getIdAttributeName() }, scope,null);
+              searchResult = this.searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[] {idAttributeName}, scope,null);
               if (searchResult.size() > 0) {
                 type = match;
                 break;
@@ -184,15 +185,16 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
               }
               if (typeConfig.isParentMembershipAttributeDN()) {
                 // ****** Begin changes ****/
-                if (findIdentityObject(ctx, memberRef) != null) {
+                IdentityObject identityObject = findIdentityObject(ctx, memberRef);
+                if (identityObject != null) {
                   if (criteria != null && criteria.getFilter() != null) {
                     String name = Tools.stripDnToName(memberRef);
                     String regex = Tools.wildcardToRegex(criteria.getFilter());
                     if (Pattern.matches(regex, name)) {
-                      objects.add(findIdentityObject(ctx, memberRef));
+                      objects.add(identityObject);
                     }
                   } else {
-                    objects.add(findIdentityObject(ctx, memberRef));
+                    objects.add(identityObject);
                   }
                 }
                 // ****** End changes ****/

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -100,13 +100,13 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
                 break;
               }
             }
-            // ****** End changes ****/
           }
         }
       }
       if (type == null) {
-        throw new IdentityException("Cannot recognize identity object type by its DN: " + dn);
+        return null;
       }
+      // ****** End changes ****/
       // Grab entry
       Name jndiName = new CompositeName().add(dn);
       Attributes attrs = ldapContext.getAttributes(jndiName);
@@ -187,10 +187,12 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
                   String name = Tools.stripDnToName(memberRef);
                   String regex = Tools.wildcardToRegex(criteria.getFilter());
                   if (Pattern.matches(regex, name)) {
-                    objects.add(findIdentityObject(ctx, memberRef));
+                    // ****** Begin changes ****/
+                    if (findIdentityObject(ctx, memberRef) != null) {
+                      objects.add(findIdentityObject(ctx, memberRef));
+                    }
                   }
                 } else {
-                  // ****** Begin changes ****/
                   if (findIdentityObject(ctx, memberRef) != null) {
                     objects.add(findIdentityObject(ctx, memberRef));
                   }

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -87,15 +87,9 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
             Object[] filterArgs = { name };
             if (filter != null) {
               searchResult = this.searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[] { getTypeConfiguration(ctx, match).getIdAttributeName() }, scope,null);
-              if (searchResult.size() == 0) {
+              if (searchResult.size() >= 0) {
                 type = match;
                 break;
-              } else {
-                LDAPIdentityObjectImpl ldapEntry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
-                if (ldapEntry != null && Tools.dnEquals(ldapEntry.getDn(), dn)) {
-                  type = match;
-                  break;
-                }
               }
             } else {
               LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -84,18 +84,24 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
           String scope = getTypeConfiguration(ctx, match).getEntrySearchScope();
           if (nameAttribute != null) {
             String name = nameAttribute.get().toString();
-            Object[] filterArgs = {name};
+            Object[] filterArgs = { name };
             if (filter != null) {
               searchResult = this.searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[] { getTypeConfiguration(ctx, match).getIdAttributeName() }, scope,null);
               if (searchResult.size() == 0) {
                 type = match;
                 break;
               } else {
-                LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
-                if ((entry != null && Tools.dnEquals(entry.getDn(), dn))) {
+                LDAPIdentityObjectImpl ldapEntry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
+                if (ldapEntry != null && Tools.dnEquals(ldapEntry.getDn(), dn)) {
                   type = match;
                   break;
                 }
+              }
+            } else {
+              LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
+              if (entry != null && Tools.dnEquals(entry.getDn(), dn)) {
+                type = match;
+                break;
               }
             }
             // ****** End changes ****/

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -76,30 +76,31 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
         //****** Begin changes ****/
         // retrieve the UID attribute from the LDAP configuration
         List<SerializableSearchResult> searchResult = null;
-        for (IdentityObjectType match : matches) {
-          LDAPIdentityObjectTypeConfiguration typeConfiguration = getTypeConfiguration(ctx, match);
+        for (IdentityObjectType possibleTypeMatch : matches) {
+          LDAPIdentityObjectTypeConfiguration typeConfiguration = getTypeConfiguration(ctx, possibleTypeMatch);
           Name jndiName = new CompositeName().add(dn);
           Attributes attrs = ldapContext.getAttributes(jndiName);
           String idAttributeName = typeConfiguration.getIdAttributeName();
           Attribute nameAttribute = attrs.get(idAttributeName);
-          String filter = getTypeConfiguration(ctx, match).getEntrySearchFilter();
-          String[] entryCtxs = getTypeConfiguration(ctx, match).getCtxDNs();
-          String scope = getTypeConfiguration(ctx, match).getEntrySearchScope();
-          if (nameAttribute != null) {
-            String name = nameAttribute.get().toString();
-            Object[] filterArgs = { name };
-            if (filter != null) {
-              searchResult = this.searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[] {idAttributeName}, scope,null);
-              if (searchResult.size() > 0) {
-                type = match;
-                break;
-              }
-            } else {
-              LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
-              if (entry != null && Tools.dnEquals(entry.getDn(), dn)) {
-                type = match;
-                break;
-              }
+          if (nameAttribute == null) {
+            continue;
+          }
+          String filter = getTypeConfiguration(ctx, possibleTypeMatch).getEntrySearchFilter();
+          String[] entryCtxs = getTypeConfiguration(ctx, possibleTypeMatch).getCtxDNs();
+          String scope = getTypeConfiguration(ctx, possibleTypeMatch).getEntrySearchScope();
+          String name = nameAttribute.get().toString();
+          Object[] filterArgs = { name };
+          if (filter != null) {
+            searchResult = this.searchIdentityObjects(ctx, entryCtxs, filter, filterArgs, new String[] { idAttributeName }, scope,null);
+            if (searchResult.size() > 0) {
+              type = possibleTypeMatch;
+              break;
+            }
+          } else {
+            LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, possibleTypeMatch);
+            if (entry != null && Tools.dnEquals(entry.getDn(), dn)) {
+              type = possibleTypeMatch;
+              break;
             }
           }
         }

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -183,21 +183,19 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
                 continue;
               }
               if (typeConfig.isParentMembershipAttributeDN()) {
-                if (criteria != null && criteria.getFilter() != null) {
-                  String name = Tools.stripDnToName(memberRef);
-                  String regex = Tools.wildcardToRegex(criteria.getFilter());
-                  if (Pattern.matches(regex, name)) {
-                    // ****** Begin changes ****/
-                    if (findIdentityObject(ctx, memberRef) != null) {
+                // ****** Begin changes ****/
+                if (findIdentityObject(ctx, memberRef) != null) {
+                  if (criteria != null && criteria.getFilter() != null) {
+                    String name = Tools.stripDnToName(memberRef);
+                    String regex = Tools.wildcardToRegex(criteria.getFilter());
+                    if (Pattern.matches(regex, name)) {
                       objects.add(findIdentityObject(ctx, memberRef));
                     }
-                  }
-                } else {
-                  if (findIdentityObject(ctx, memberRef) != null) {
+                  } else {
                     objects.add(findIdentityObject(ctx, memberRef));
                   }
-                  // ****** End changes ****/
                 }
+                // ****** End changes ****/
               } else {
                 // TODO: if relationships are not refered with DNs and only
                 // names its not possible to map

--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/ldap/ExoLDAPIdentityStoreImpl.java
@@ -80,7 +80,8 @@ public class ExoLDAPIdentityStoreImpl extends LDAPIdentityStoreImpl {
           if (nameAttribute != null) {
             String name = nameAttribute.get().toString();
             LDAPIdentityObjectImpl entry = (LDAPIdentityObjectImpl) this.findIdentityObject(ctx, name, match);
-            if (entry != null && Tools.dnEquals(entry.getDn(), dn)) {
+            String filter = getTypeConfiguration(ctx, match).getEntrySearchFilter();
+            if ((entry != null && Tools.dnEquals(entry.getDn(), dn)) || filter != null) {
               type = match;
               break;
             }

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
@@ -1,16 +1,8 @@
 package org.exoplatform.services.organization;
 
 import exo.portal.component.identiy.opendsconfig.opends.OpenDSService;
-
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-
 import junit.framework.Assert;
-
 import org.apache.commons.lang.StringUtils;
-
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.component.test.ConfigurationUnit;
 import org.exoplatform.component.test.ConfiguredBy;
@@ -18,7 +10,15 @@ import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.idm.*;
+import org.exoplatform.services.organization.idm.Config;
+import org.exoplatform.services.organization.idm.PicketLinkIDMCacheService;
+import org.exoplatform.services.organization.idm.PicketLinkIDMOrganizationServiceImpl;
+import org.exoplatform.services.organization.idm.UserDAOImpl;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Created by exo on 5/5/16.
@@ -117,6 +117,15 @@ public class TestLDAPOrganization extends TestOrganization {
 
       Collection childGoups = handler.findGroups(group);
       Assert.assertTrue(childGoups.size() > 0);
+  }
+
+  public void testFindFilteredGroup() throws Exception {
+    GroupHandler handler = organizationService.getGroupHandler();
+    Group filteredGroup = handler.findGroupById("/organization_hierarcy/filteredSubOrganizationC");
+    assertNull(filteredGroup);
+
+    Group existingGroup =  handler.findGroupById("/organization_hierarcy/OrganizationC");
+    assertNotNull(existingGroup);
   }
 
   public void testFindUser() throws Exception {

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPUserOnlyOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPUserOnlyOrganization.java
@@ -1,20 +1,9 @@
 package org.exoplatform.services.organization;
 
-import exo.portal.component.identiy.opendsconfig.opends.OpenDSService;
-
-import java.util.Collection;
-import java.util.Date;
-
-import junit.framework.Assert;
-
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.component.test.ConfigurationUnit;
 import org.exoplatform.component.test.ConfiguredBy;
 import org.exoplatform.component.test.ContainerScope;
-import org.exoplatform.container.PortalContainer;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.idm.*;
 
 /**
  * Created by exo on 5/5/16.
@@ -56,6 +45,10 @@ public class TestLDAPUserOnlyOrganization extends TestLDAPOrganization {
 
   public void testFindUser() throws Exception {
     // Disable this test because it deletes an entry from LDAP
+  }
+
+  public void testFindFilteredGroup() throws Exception {
+    // Needed only to build
   }
 
 }

--- a/component/identity/src/test/resources/conf/exo.portal.component.identity-picketlink-idm-ldap-config.xml
+++ b/component/identity/src/test/resources/conf/exo.portal.component.identity-picketlink-idm-ldap-config.xml
@@ -122,6 +122,7 @@
             </identity-store>
             <identity-store>
                 <id>PortalLDAPStore</id>
+                <!-- the new ExoLDAPIdentityStoreImpl is already in use -->
                 <class>org.picketlink.idm.impl.store.ldap.ExoLDAPIdentityStoreImpl</class>
                 <external-config/>
                 <supported-relationship-types>
@@ -229,7 +230,7 @@
                         </option>
                         <option>
                           <name>entrySearchFilter</name>
-                          <value><![CDATA[(&(cn={0})(objectClass=groupOfNames))]]></value>
+                          <value><![CDATA[(&(cn={0})(objectClass=groupOfNames)(!(cn=filteredSubOrganizationC)))]]></value>
                         </option>
                         <option>
                           <name>parentMembershipAttributePlaceholder</name>

--- a/component/identity/src/test/resources/ldap/ldap/initial-opends.ldif
+++ b/component/identity/src/test/resources/ldap/ldap/initial-opends.ldif
@@ -220,6 +220,14 @@ description: Some organization
 member: cn=User,ou=Roles,o=test,dc=portal,dc=example,dc=com
 member: cn=Admin,ou=Roles,o=test,dc=portal,dc=example,dc=com
 
+dn: cn=filteredSubOrganizationC,ou=GroupsHierarchy,o=test,dc=portal,dc=example,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: filteredSubOrganizationC
+description: Some organization
+member: cn=User,ou=Roles,o=test,dc=portal,dc=example,dc=com
+member: cn=Admin,ou=Roles,o=test,dc=portal,dc=example,dc=com
+
 dn: ou=Organizations,o=test,dc=portal,dc=example,dc=com
 objectclass: top
 objectclass: organizationalUnit


### PR DESCRIPTION
…sing filter in the picketLink configuration

fix description : 

* When using a filter, the DN of the filtered group is detected. But when we try to find its entry by calling findIdentityObject(), it returns null then the IdentityObjectType will be also null, in this case an IdentityException is thrown. In order to avoid this problem, we check if a filter is used or not and if the searchIdentityObjects() size is equal to 0, if yes we set also the IdentityObjectType with the matched value.  