### PR TITLE
EXOGTN-2298 : return a null profile when its attributes set is empty to have the same behavior between the cacheable and not cacheable implementations

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableUserProfileHandlerImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableUserProfileHandlerImpl.java
@@ -89,7 +89,8 @@ public class CacheableUserProfileHandlerImpl extends UserProfileDAOImpl {
     if (disableCacheInThread.get() == null || !disableCacheInThread.get()) {
       userProfile = (UserProfile) userProfileCache.get(userName);
       userProfile = (userProfile == null || userProfile == NULL_OBJECT
-          || StringUtils.isBlank(userProfile.getUserName())) ? null : userProfile;
+          || StringUtils.isBlank(userProfile.getUserName())
+          || userProfile.getUserInfoMap() == null || userProfile.getUserInfoMap().isEmpty()) ? null : userProfile;
       if (userProfile != null)
         return userProfile;
     }


### PR DESCRIPTION
The org.exoplatform.services.organization.idm.UserProfileDAOImpl#saveUserProfile method checks if the profile already exists or not in order to know if we are in a creation or an update operation.
With the previous implementation of the UserProfileDAOImpl, the profile was not found in the database during the creation process, so it correctly flagged the operation as a creation. With the new cacheable implementation CacheableUserProfileHandlerImpl, the profile is already in cache (but with an empty attribute set), therefore it finds a non-null profile and considers the operation as an update (and therefore update the fullname since it considers that the information have changed).
This PR updates the method CacheableUserProfileHandlerImpl#getProfile to consider a profile with an empty attribute set as a null profile, in order to have the same behavior than UserProfileDAOImpl#getProfile.