### PR TITLE
EXOGTN-2296 : do not set cache entry to NULL_OBJECT after fecthing null from the cache, but only after fetching null from the data storage

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableUserProfileHandlerImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableUserProfileHandlerImpl.java
@@ -59,11 +59,7 @@ public class CacheableUserProfileHandlerImpl extends UserProfileDAOImpl {
   public UserProfile findUserProfileByName(String userName) throws Exception {
     UserProfile userProfile = null;
     if (disableCacheInThread.get() == null || !disableCacheInThread.get()) {
-      userProfile = (UserProfile) userProfileCache.get(userName);
-      if (userProfile == null) {
-        userProfile = NULL_OBJECT;
-        userProfileCache.put(userName, userProfile);
-      }
+      userProfile = userProfileCache.get(userName);
     }
 
     if (userProfile == null) {

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestOrganization.java
@@ -38,6 +38,8 @@ import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.organization.idm.Config;
 import org.exoplatform.services.organization.idm.PicketLinkIDMOrganizationServiceImpl;
 import org.exoplatform.services.organization.idm.UpdateLoginTimeListener;
+import org.exoplatform.services.organization.idm.cache.CacheableUserProfileHandlerImpl;
+import org.exoplatform.services.organization.impl.UserProfileImpl;
 import org.exoplatform.services.security.ConversationRegistry;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
@@ -301,6 +303,38 @@ public class TestOrganization extends AbstractKernelTest {
         MembershipType membershipType = mtHandler_.findMembershipType(mt.getName());
         assertNotNull("Membership type " + testType + " must be exist", membershipType);
         assertEquals("Expect mebershiptype is:", testType, mtHandler_.findMembershipType(testType).getName());
+    }
+
+    public void testFindUserProfile() throws Exception {
+        // Given
+        UserProfileHandler userProfileHandler = organizationService.getUserProfileHandler();
+        UserProfile userProfile = new UserProfileImpl(USER_1);
+        userProfile.setAttribute("user.employer", "eXo");
+        userProfileHandler.saveUserProfile(userProfile, false);
+        if (userProfileHandler instanceof CacheableUserProfileHandlerImpl) {
+            ((CacheableUserProfileHandlerImpl) userProfileHandler).clearCache();
+        }
+
+        // When
+        UserProfile fetchedUserProfile = userProfileHandler.findUserProfileByName(USER_1);
+
+        // Then
+        assertNotNull(fetchedUserProfile);
+        assertEquals(USER_1, fetchedUserProfile.getUserName());
+    }
+
+    public void testNotFindUserProfile() throws Exception {
+        // Given
+        UserProfileHandler userProfileHandler = organizationService.getUserProfileHandler();
+        if (userProfileHandler instanceof CacheableUserProfileHandlerImpl) {
+            ((CacheableUserProfileHandlerImpl) userProfileHandler).clearCache();
+        }
+
+        // When
+        UserProfile userProfile = userProfileHandler.findUserProfileByName("not_existing_user");
+
+        // Then
+        assertNull(userProfile);
     }
 
     protected void createGroup(String parent, String name) {


### PR DESCRIPTION
First, the issue is not about stored data since the user profile language is correctly updated in the database when the user changes his language.
The problem comes from org.exoplatform.services.organization.idm.cache.CacheableUserProfileHandlerImpl#findUserProfileByName which stores NULL_OBJECT in the cache entry when the given user is not in the cache.
In the current issue, when the session has expired and the cache is empty for the given user, this method set the cache entry to NULL_OBJECT, as is the user does not exist. Then when calculating the user language in org.exoplatform.portal.application.localization.DefaultLocalePolicyService#getLocaleConfigForRegistered, since the fetched UserProfile is null, and the session has expired, the locale is taken from the browser, so it comes back to the default locale of the browser.