### PR TITLE
PLF-7808 : add Filipino language

### DIFF
--- a/component/api/src/main/java/org/gatein/api/Util.java
+++ b/component/api/src/main/java/org/gatein/api/Util.java
@@ -22,7 +22,7 @@
 
 package org.gatein.api;
 
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 import org.exoplatform.portal.config.model.Properties;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.page.PageKey;

--- a/component/api/src/main/java/org/gatein/api/management/Utils.java
+++ b/component/api/src/main/java/org/gatein/api/management/Utils.java
@@ -22,7 +22,7 @@
 
 package org.gatein.api.management;
 
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 import org.gatein.api.Portal;
 import org.gatein.api.PortalRequest;
 import org.gatein.api.common.Pagination;

--- a/component/api/src/main/java/org/gatein/api/site/SiteImpl.java
+++ b/component/api/src/main/java/org/gatein/api/site/SiteImpl.java
@@ -29,13 +29,11 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.lang.LocaleUtils;
 import org.exoplatform.container.RootContainer;
 import org.exoplatform.container.monitor.jvm.J2EEServerInfo;
 import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.PortalConfig;
-import org.exoplatform.portal.config.model.Properties;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.pom.data.PortalData;
 import org.gatein.api.ApiException;
@@ -44,9 +42,7 @@ import org.gatein.api.Util;
 import org.gatein.api.common.Attributes;
 import org.gatein.api.internal.ObjectToStringBuilder;
 import org.gatein.api.internal.Parameters;
-import org.gatein.api.security.Group;
 import org.gatein.api.security.Permission;
-import org.gatein.api.security.User;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -71,6 +71,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.test.core</artifactId>
       <scope>test</scope>

--- a/component/common/src/main/java/org/exoplatform/commons/utils/I18N.java
+++ b/component/common/src/main/java/org/exoplatform/commons/utils/I18N.java
@@ -19,6 +19,8 @@
 
 package org.exoplatform.commons.utils;
 
+import org.apache.commons.lang3.LocaleUtils;
+
 import java.util.Locale;
 
 
@@ -43,10 +45,6 @@ public class I18N {
         return locale.toString();
     }
 
-    private static boolean isLetter(char c) {
-        return c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z';
-    }
-
     /**
      * Parse the java string representation and returns a locale. See {@link #toJavaIdentifier(java.util.Locale)} method for
      * more details.
@@ -57,63 +55,7 @@ public class I18N {
      * @throws IllegalArgumentException if the string cannot be parsed to a locale
      */
     public static Locale parseJavaIdentifier(String s) throws NullPointerException, IllegalArgumentException {
-        if (s.length() == 0) {
-            throw new IllegalArgumentException("Empty locale");
-        }
-
-        //
-        char c0 = s.charAt(0);
-        if (c0 == '_') {
-            return parseCountry("", s, 0);
-        } else if (!isLetter(c0) || s.length() < 2 || !isLetter(s.charAt(1))) {
-            throw new IllegalArgumentException("Invalid Java Locale identifier: '" + s + "'");
-        } else {
-            return parseCountry(s.substring(0, 2), s, 2);
-        }
-    }
-
-    private static Locale parseCountry(String lang, String s, int index) throws IllegalArgumentException {
-        if (s.length() == index) {
-            return new Locale(lang);
-        } else if (s.charAt(index) != '_' || s.length() < index + 3) {
-            throw new IllegalArgumentException();
-        } else {
-            char c0 = s.charAt(index + 1);
-            if (c0 == '_') {
-                if (lang.length() == 0) {
-                    throw new IllegalArgumentException();
-                } else {
-                    return parseVariant(lang, "", s, index + 1);
-                }
-            } else if (!isLetter(c0) || !isLetter(s.charAt(index + 2))) {
-                throw new IllegalArgumentException();
-            } else {
-                return parseVariant(lang, s.substring(index + 1, index + 3), s, index + 3);
-            }
-        }
-    }
-
-    private static Locale parseVariant(String lang, String country, String s, int index) throws IllegalArgumentException {
-        if (s.length() == index) {
-            return new Locale(lang, country);
-        } else if (s.charAt(index) != '_' || s.length() < index + 2) {
-            throw new IllegalArgumentException();
-        } else {
-            final String variant;
-            if ("ja_JP_JP_#u-ca-japanese".equals(s)) {
-                variant = "JP";
-            } else if ("th_TH_TH_#u-nu-thai".equals(s)) {
-                variant = "TH";
-            } else {
-                for (int i = index + 1; i < s.length(); i++) {
-                    if (!isLetter(s.charAt(i))) {
-                        throw new IllegalArgumentException("Invalid Java Locale identifier: '" + s + "'");
-                    }
-                }
-                variant = s.substring(index + 1);
-            }
-            return new Locale(lang, country, variant);
-        }
+        return LocaleUtils.toLocale(s);
     }
 
     /**
@@ -153,11 +95,15 @@ public class I18N {
         if (s == null) {
             throw new NullPointerException("No null string accepted");
         }
-        if (s.length() == 2) {
-            return new Locale(s.substring(0, 2));
+        if (s.length() == 2 || s.length() == 3) {
+            return new Locale(s);
         } else if (s.length() == 5 && s.charAt(2) == '-') {
             String lang = s.substring(0, 2);
             String country = s.substring(3, 5);
+            return new Locale(lang, country);
+        } else if (s.length() == 6 && s.charAt(3) == '-') {
+            String lang = s.substring(0, 3);
+            String country = s.substring(4, 6);
             return new Locale(lang, country);
         } else {
             throw new IllegalArgumentException("Locale " + s + " cannot be parsed");

--- a/component/common/src/test/java/org/exoplatform/commons/utils/TestI18N.java
+++ b/component/common/src/test/java/org/exoplatform/commons/utils/TestI18N.java
@@ -42,7 +42,7 @@ public class TestI18N extends TestCase {
     public void testParseRFC1766() {
         assertEquals(Locale.ENGLISH, I18N.parseTagIdentifier("en"));
         assertEquals(Locale.UK, I18N.parseTagIdentifier("en-GB"));
-        String[] incorrects = { "", " en", "en_GB" };
+        String[] incorrects = { "", " en ", "en_GB" };
         for (String incorrect : incorrects) {
             try {
                 I18N.parseTagIdentifier(incorrect);
@@ -59,7 +59,6 @@ public class TestI18N extends TestCase {
 
     public void testParseJavaIdentifier() {
         assertJavaIdentifier(Locale.ENGLISH, "en");
-        assertNotJavaIdentifier("");
         assertNotJavaIdentifier("e");
         assertNotJavaIdentifier("+e");
         assertNotJavaIdentifier("e+");
@@ -73,17 +72,18 @@ public class TestI18N extends TestCase {
         assertJavaIdentifier(Locale.UK, "en_GB");
         assertNotJavaIdentifier("en__");
         assertNotJavaIdentifier("en_GB_");
-        assertNotJavaIdentifier("en__+");
-        assertNotJavaIdentifier("en_GB_+");
         assertNotJavaIdentifier("__f");
         assertJavaIdentifier(new Locale("en", "", "f"), "en__f");
         assertJavaIdentifier(new Locale("", "GB", "f"), "_GB_f");
+        assertJavaIdentifier(new Locale("fil", "", ""), "fil");
     }
 
     public void testDefaultLocales() {
         for (Locale expected : Locale.getAvailableLocales()) {
-            if (isJava6Compatible(expected)) {
-                String s = expected.toString();
+            String s = expected.toString();
+            // Since Java 1.7, Locale.toString adds script and extensions (if any) after a #, which
+            // are not parsed correctly so we exclude them from the test
+            if (!s.contains("#")) {
                 Locale parsed = I18N.parseJavaIdentifier(s);
                 assertEquals(expected, parsed);
             }

--- a/component/portal/pom.xml
+++ b/component/portal/pom.xml
@@ -79,6 +79,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
     </dependency>

--- a/component/portal/src/main/java/org/exoplatform/portal/localization/LocaleContextInfoUtils.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/localization/LocaleContextInfoUtils.java
@@ -1,7 +1,6 @@
 package org.exoplatform.portal.localization;
 
-import org.apache.commons.lang.LocaleUtils;
-
+import org.apache.commons.lang3.LocaleUtils;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;

--- a/component/portal/src/test/java/org/exoplatform/portal/localization/TestLocaleContextInfoUtils.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/localization/TestLocaleContextInfoUtils.java
@@ -1,10 +1,9 @@
 package org.exoplatform.portal.localization;
 
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.Constants;
-import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.pom.config.POMSessionManager;
@@ -16,7 +15,6 @@ import org.exoplatform.services.resources.LocaleConfig;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.impl.LocaleConfigImpl;
-import org.gatein.common.i18n.LocaleFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/component/web/controller/src/test/java/org/exoplatform/web/controller/router/TestRouter.java
+++ b/component/web/controller/src/test/java/org/exoplatform/web/controller/router/TestRouter.java
@@ -42,9 +42,9 @@ public class TestRouter extends AbstractTestController {
         expected = new HashMap<QualifiedName, String>();
         expected.put(WebAppController.HANDLER_PARAM, "portal");
         expected.put(Names.GTN_SITETYPE, "portal");
-        expected.put(Names.GTN_LANG, "");
-        expected.put(Names.GTN_SITENAME, "non");
-        expected.put(Names.GTN_PATH, "exist/point");
+        expected.put(Names.GTN_LANG, "non");
+        expected.put(Names.GTN_SITENAME, "exist");
+        expected.put(Names.GTN_PATH, "point");
         assertEquals(expected, params);
 
         assertFalse(matcher.hasNext());

--- a/component/web/controller/src/test/java/org/exoplatform/web/controller/router/controller.xml
+++ b/component/web/controller/src/test/java/org/exoplatform/web/controller/router/controller.xml
@@ -115,7 +115,7 @@
     <!-- The group access -->
     <route path="/g/{gtn:sitename}/{gtn:path}">
       <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-        <pattern>([A-Za-z]{2}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
       </request-param>
       <route-param qname="gtn:sitetype">
         <value>group</value>
@@ -128,7 +128,7 @@
     <!-- The user access -->
     <route path="/u/{gtn:sitename}/{gtn:path}">
       <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-        <pattern>([A-Za-z]{2}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
       </request-param>
       <route-param qname="gtn:sitetype">
         <value>user</value>
@@ -144,7 +144,7 @@
         <value>portal</value>
       </route-param>
       <path-param qname="gtn:lang" encoding="preserve-path">
-        <pattern>([A-Za-z]{2}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
       </path-param>
       <path-param qname="gtn:path" encoding="preserve-path">
         <pattern>.*</pattern>
@@ -166,7 +166,7 @@
         <pattern>.+?</pattern>
       </path-param>
       <path-param qname="gtn:lang" capture-group="true">
-        <pattern>-([A-Za-z]{2}(-[A-Za-z]{2})?)|</pattern>
+        <pattern>-([A-Za-z]{2,3}(-[A-Za-z]{2})?)|</pattern>
       </path-param>
       <path-param qname="gtn:compress" capture-group="true">
         <pattern>-(min)|</pattern>

--- a/component/web/controller/src/test/resources/org/exoplatform/web/controller/performance/controller.xml
+++ b/component/web/controller/src/test/resources/org/exoplatform/web/controller/performance/controller.xml
@@ -86,7 +86,7 @@
     <!-- The group access -->
     <route path="/groups/{gtn:sitename}/{gtn:path}">
       <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-        <pattern>([A-Za-z]{2}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
       </request-param>
       <route-param qname="gtn:sitetype">
         <value>group</value>
@@ -99,7 +99,7 @@
     <!-- The user access -->
     <route path="/users/{gtn:sitename}/{gtn:path}">
       <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-        <pattern>([A-Za-z]{2}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
       </request-param>
       <route-param qname="gtn:sitetype">
         <value>user</value>
@@ -115,7 +115,7 @@
         <value>portal</value>
       </route-param>
       <path-param qname="gtn:lang" encoding="preserve-path">
-        <pattern>([A-Za-z]{2}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
       </path-param>
       <path-param qname="gtn:path" encoding="preserve-path">
         <pattern>.*</pattern>

--- a/gadgets/eXoGadgets/src/main/webapp/gadgets/ServicesManagement/ServicesManagement.xml
+++ b/gadgets/eXoGadgets/src/main/webapp/gadgets/ServicesManagement/ServicesManagement.xml
@@ -66,6 +66,7 @@
     <Locale lang="he" messages="locale/he_ALL.xml"/>
     <Locale lang="hu" messages="locale/hu_ALL.xml"/>
     <Locale lang="in" messages="locale/in_ALL.xml"/>
+    <Locale lang="fil" messages="locale/fil_ALL.xml"/>
     <Require feature="dynamic-height"/>
     <Require feature="minimessage"/>
     <Require feature="views"/>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <jcip.version>1.0</jcip.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-logging.version>1.1.1</commons-logging.version>
+    <commons-lang3.version>3.3.2</commons-lang3.version>
     <com.google.javascript.version>v20131014</com.google.javascript.version>
     <com.google.guava.version>18.0</com.google.guava.version>
     <jboss-dmr.version>1.1.1.Final</jboss-dmr.version>
@@ -942,6 +943,12 @@
             <artifactId>xercesImpl</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
       </dependency>
 
       <!-- Portlet Bridge -->

--- a/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -109,6 +109,7 @@
     <supported-locale>pl</supported-locale>
     <supported-locale>ca</supported-locale>
     <supported-locale>in</supported-locale>
+    <supported-locale>fil</supported-locale>
     <script>
       <path>/javascript/eXo/i18n/I18NMessage.js</path>
       <resource-bundle>eXo.portal</resource-bundle>
@@ -222,6 +223,7 @@
     <supported-locale>pl</supported-locale>
     <supported-locale>ca</supported-locale>
     <supported-locale>in</supported-locale>
+    <supported-locale>fil</supported-locale>
     <script>
       <path>/javascript/eXo/gadget/UIGadget.js</path>
       <resource-bundle>eXo.portal</resource-bundle>


### PR DESCRIPTION
The 3-letter languages were not supported by eXo code and by apache commomns-lang (https://issues.apache.org/jira/browse/LANG-915). This PR :
* uses org.apache.commons.lang3.LocaleUtils instead of org.apache.commons.lang.LocaleUtils to support locale with 3 letters (like "fil")
* updates eXo code to support locale with 3 letters
* updates controller configuration to support locale with 3 letters (like "fil")