### PR TITLE
ECMS-7850 : Make the Add New Site button display on both top and bottom of the Site Management page

### DIFF
--- a/web/eXoResources/src/main/webapp/groovy/navigation/webui/component/UISiteManagement.gtmpl
+++ b/web/eXoResources/src/main/webapp/groovy/navigation/webui/component/UISiteManagement.gtmpl
@@ -30,6 +30,9 @@
                 <div class="nothingEditable center">$noSitesLabel</div>  
       <%    } else {           
       %>
+         <div class="uiAction uiActionBorder">
+         				<a href="javascript:void(0);" onclick="ajaxGet(eXo.env.server.createPortalURL('UIWorkingWorkspace', 'CreatePortal', true))" class="btn"><%=_ctx.appRes(uicomponent.getId() + ".action.addNewPortal")%></a>
+         </div>
 		 <table class="managementBlock" summary="Sites edit">
 		   		<tr style="display: none;">
                  <th scope="col">Site</th>
@@ -88,11 +91,7 @@
 			<%
            }
 				if(uicomponent.getPortalConfigs() != null && uicomponent.getPortalConfigs().size() > 0){
-			%>
-			<div class="uiAction uiActionBorder"> 
-				<a href="javascript:void(0);" onclick="ajaxGet(eXo.env.server.createPortalURL('UIWorkingWorkspace', 'CreatePortal', true))" class="btn"><%=_ctx.appRes(uicomponent.getId() + ".action.addNewPortal")%></a>
-			</div>
-			<%
+
 				}
 			%>
 			<%uicomponent.renderChildren();%>

--- a/web/eXoResources/src/main/webapp/groovy/navigation/webui/component/UISiteManagement.gtmpl
+++ b/web/eXoResources/src/main/webapp/groovy/navigation/webui/component/UISiteManagement.gtmpl
@@ -31,7 +31,7 @@
       <%    } else {           
       %>
          <div class="uiAction uiActionBorder">
-         				<a href="javascript:void(0);" onclick="ajaxGet(eXo.env.server.createPortalURL('UIWorkingWorkspace', 'CreatePortal', true))" class="btn"><%=_ctx.appRes(uicomponent.getId() + ".action.addNewPortal")%></a>
+                  				<a href="javascript:void(0);" onclick="ajaxGet(eXo.env.server.createPortalURL('UIWorkingWorkspace', 'CreatePortal', true))" class="btn"><%=_ctx.appRes(uicomponent.getId() + ".action.addNewPortal")%></a>
          </div>
 		 <table class="managementBlock" summary="Sites edit">
 		   		<tr style="display: none;">
@@ -91,7 +91,11 @@
 			<%
            }
 				if(uicomponent.getPortalConfigs() != null && uicomponent.getPortalConfigs().size() > 0){
-
+			%>
+			<div class="uiAction uiActionBorder">
+				<a href="javascript:void(0);" onclick="ajaxGet(eXo.env.server.createPortalURL('UIWorkingWorkspace', 'CreatePortal', true))" class="btn"><%=_ctx.appRes(uicomponent.getId() + ".action.addNewPortal")%></a>
+			</div>
+			<%
 				}
 			%>
 			<%uicomponent.renderChildren();%>

--- a/web/eXoResources/src/main/webapp/groovy/navigation/webui/component/UISiteManagement.gtmpl
+++ b/web/eXoResources/src/main/webapp/groovy/navigation/webui/component/UISiteManagement.gtmpl
@@ -30,7 +30,7 @@
                 <div class="nothingEditable center">$noSitesLabel</div>  
       <%    } else {           
       %>
-         <div class="uiAction uiActionBorder">
+         <div id="top" class="uiAction uiActionBorder">
                   				<a href="javascript:void(0);" onclick="ajaxGet(eXo.env.server.createPortalURL('UIWorkingWorkspace', 'CreatePortal', true))" class="btn"><%=_ctx.appRes(uicomponent.getId() + ".action.addNewPortal")%></a>
          </div>
 		 <table class="managementBlock" summary="Sites edit">


### PR DESCRIPTION
As described in the PFR-1592, the Add New Site button should be displayed on both top and bottom of the Site Management page. So i added a second button html tag which is (<div id="top" class="uiAction uiActionBorder">) on top of the table html tag.
Also i changed some css properties to make it display correctly, as of the "margin: -16px -15px 0" and "padding-bottom: inherit" for the "#top.uiManagementSite .uiBox .uiContentBox".