### PR TITLE
PLF-8449:Remove any space when registering usernames

### DIFF
--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/MultipleConditionsValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/MultipleConditionsValidator.java
@@ -32,6 +32,9 @@ import org.exoplatform.webui.form.UIFormInput;
 /** @author <a href="mailto:chris.laprun@jboss.com">Chris Laprun</a> */
 public abstract class MultipleConditionsValidator extends AbstractValidator implements Serializable {
     public void validate(UIFormInput uiInput) throws Exception {
+        if (uiInput.getName().equals("username")) {
+            trimValue = false;
+        }
         String value = trimmedValueOrNullIfBypassed((String) uiInput.getValue(), uiInput, exceptionOnMissingMandatory,
                 trimValue);
         if (value == null) {

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/MultipleConditionsValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/MultipleConditionsValidator.java
@@ -32,9 +32,6 @@ import org.exoplatform.webui.form.UIFormInput;
 /** @author <a href="mailto:chris.laprun@jboss.com">Chris Laprun</a> */
 public abstract class MultipleConditionsValidator extends AbstractValidator implements Serializable {
     public void validate(UIFormInput uiInput) throws Exception {
-        if (uiInput.getName().equals("username")) {
-            trimValue = false;
-        }
         String value = trimmedValueOrNullIfBypassed((String) uiInput.getValue(), uiInput, exceptionOnMissingMandatory,
                 trimValue);
         if (value == null) {

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/UserConfigurableValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/UserConfigurableValidator.java
@@ -138,7 +138,7 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
     public UserConfigurableValidator(String configurationName, String messageLocalizationKey,
             Boolean exceptionOnMissingMandatory) {
         this.exceptionOnMissingMandatory = exceptionOnMissingMandatory;
-        this.trimValue = true;
+        this.trimValue = configurationName == null || !USERNAME.equals(configurationName);
         localizationKey = messageLocalizationKey != null ? messageLocalizationKey : DEFAULT_LOCALIZATION_KEY;
         this.validatorName = configurationName != null ? configurationName : USERNAME;
     }


### PR DESCRIPTION
-trimmedValueOrNullIfBypassed: this method will remove any white spaces in the start and end of the word. so we should enter the username without applying any trim for the first time and for the reason of regex detection of space in the word