### PR TITLE
Fix displaying Site properties with selected site instead of current site

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalComponentActionListener.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalComponentActionListener.java
@@ -31,6 +31,7 @@ import org.exoplatform.portal.config.model.ApplicationType;
 import org.exoplatform.portal.config.model.CloneApplicationState;
 import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.TransientApplicationState;
+import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.webui.application.PortletState;
 import org.exoplatform.portal.webui.application.UIPortlet;
 import org.exoplatform.portal.webui.container.UIComponentFactory;
@@ -469,7 +470,7 @@ public class UIPortalComponentActionListener {
 
             UIMaskWorkspace uiMaskWS = uiApp.getChildById(UIPortalApplication.UI_MASK_WS_ID);
             UIPortalForm portalForm = uiMaskWS.createUIComponent(UIPortalForm.class, null, "UIPortalForm");
-            portalForm.setEditingSiteKey(uiPortal.getSiteKey());
+            portalForm.setEditingSiteKey(SiteKey.portal(portalName));
             portalForm.setBindingBean();
             uiMaskWS.setWindowSize(700, -1);
             context.addUIComponentToUpdateByAjax(uiMaskWS);


### PR DESCRIPTION
The Site properties layout has to display selected site properties instead of current site. Thus, the parameter `portalName` should be used assuming that this action is used in sites of type 'portal' only